### PR TITLE
React Runner implementation - fix error spacing and blurred input text

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -289,6 +289,8 @@ export default function Demo(props) {
   const DemoRoot = asPathWithoutLang.startsWith('/joy-ui') ? DemoRootJoy : DemoRootMaterial;
   const Wrapper = asPathWithoutLang.startsWith('/joy-ui') ? BrandingProvider : React.Fragment;
 
+  const isAdVisible = showAd && !disableAd && !demoOptions.disableAd;
+
   return (
     <Root>
       <AnchorLink id={`${demoName}`} />
@@ -357,13 +359,13 @@ export default function Demo(props) {
               variant="outlined"
               error
               component="pre"
-              sx={{ whiteSpace: 'pre-wrap', mb: 1 }}
+              sx={{ whiteSpace: 'pre-wrap', mb: isAdVisible ? 3 : 1 }}
             >
               {debouncedError}
             </FormHelperText>
           )}
         </Collapse>
-        {showAd && !disableAd && !demoOptions.disableAd ? <AdCarbonInline /> : null}
+        {isAdVisible ? <AdCarbonInline /> : null}
       </Wrapper>
     </Root>
   );

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -61,7 +61,7 @@
   "decreaseSpacing": "decrease spacing",
   "demoToolbarLabel": "demo source",
   "diamondSponsors": "Diamond Sponsors",
-  "editorHint": "Press <kbd>Enter</kbd> to start editing, press <kbd>Escape</kbd> to exit",
+  "editorHint": "Press <kbd>Enter</kbd> to start editing",
   "editPage": "Edit this page",
   "emojiLove": "Love",
   "emoojiWarning": "Warning",


### PR DESCRIPTION
- Fix spacing around error message when there is an ad below the editor, so that the error is visually grouped with the respective editor
- Remove "Esc" instructions after escaping text input, as in that situation further pressing of "Esc" was not making any changes and the cursor was already not showing anymore

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/material-ui/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).
